### PR TITLE
Restart on qemu.conf change

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
     group: root
     mode: 0600
   notify:
-    - reload libvirt
+    - restart libvirt
 
 - name: Create qemu-lockd.conf configuration file
   template:


### PR DESCRIPTION
It seems like reloading libvirtd when a change is done in qemu.conf is 
not enough.

When changing the libvirt_qemu_user setting the reload does not make the 
change effective.

Tested on libvirt 3.0.0